### PR TITLE
Fix typo in ciarlet.md

### DIFF
--- a/pages/ciarlet.md
+++ b/pages/ciarlet.md
@@ -60,7 +60,7 @@ An order 1 [Lagrange space](element::lagrange) on a triangle is defined by:
 <li>\({{symbols.dual_basis}}=\{{{symbols.functional}}_0,{{symbols.functional}}_1,{{symbols.functional}}_2\}\).
 </ul>
 
-The functionals \({{symbols.functional}}_1\) to \({{symbols.functional}}_3\) are defined as
+The functionals \({{symbols.functional}}_0\) to \({{symbols.functional}}_2\) are defined as
 point evaluations at the three vertices of the triangle:
 
 \[{{symbols.functional}}_0:v\mapsto v(0,0)\]


### PR DESCRIPTION
Found a typo. See https://defelement.com/ciarlet.html#Example%3A+Order+1+Lagrange+space+on+a+triangle . It should be the functionals l_0 to l_2 instead of l_1 to l_3