### PR TITLE
install fenics-basix rather than installing from github

### DIFF
--- a/defelement/implementations/basix.py
+++ b/defelement/implementations/basix.py
@@ -125,5 +125,4 @@ class BasixImplementation(Implementation):
     name = "Basix"
     url = "https://github.com/FEniCS/basix"
     verification = True
-    install = "pip3 install git+https://github.com/FEniCS/basix"
-    # install = "pip3 install fenics-basix"
+    install = "pip3 install fenics-basix"

--- a/defelement/implementations/basix_ufl.py
+++ b/defelement/implementations/basix_ufl.py
@@ -141,5 +141,4 @@ class BasixUFLImplementation(Implementation):
     name = "Basix.UFL"
     url = "https://github.com/FEniCS/basix"
     verification = True
-    install = "pip3 install git+https://github.com/FEniCS/basix fenics-ufl"
-    # install = "pip3 install fenics-basix fenics-ufl"
+    install = "pip3 install fenics-basix fenics-ufl"


### PR DESCRIPTION
Now that Basix has a newer release, we can install the release rather than installing directly from github