### PR TITLE
Adjust tolerance in verification

### DIFF
--- a/defelement/verification.py
+++ b/defelement/verification.py
@@ -142,7 +142,7 @@ def same_span(table0: NDArray[float64], table1: NDArray[float64], complete: bool
         return False
 
     stack = np.hstack([table0, table1])
-    srank = np.linalg.matrix_rank(stack)
+    srank = np.linalg.matrix_rank(stack, tol=1e-11)
     return rank0 == srank
 
 

--- a/defelement/verification.py
+++ b/defelement/verification.py
@@ -142,7 +142,7 @@ def same_span(table0: NDArray[float64], table1: NDArray[float64], complete: bool
         return False
 
     stack = np.hstack([table0, table1])
-    srank = np.linalg.matrix_rank(stack, tol=1e-11)
+    srank = np.linalg.matrix_rank(stack, tol=1e-8)
     return rank0 == srank
 
 


### PR DESCRIPTION
This will allow the failing verifications at https://defelement.org/verification/basix.ufl.html to pass - these definitely should pass as they're elements defined using Symfem's [Basix interface](https://github.com/mscroggs/symfem/blob/f7da40c7236b2e1fc3151c7869e6215f2ae4c003/demo/basix_interface.py) so should be copies of the Symfem elements